### PR TITLE
Missing instructions for CXX

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ command-line parameters.
 -----------------------------------------
 Building Instructions for Linux* OS
 -----------------------------------------
-1) Set the CC variable to point to the appropriate compiler wrapper, mpiicc or 
-   mpicc.
+1) Set the CC and CXX variables to point to the appropriate compiler wrappers,
+   mpiicc or mpicc for C, mpiicpc or mpicxx for C++.
 2) Run one or more Makefile commands below:
 
    make clean - remove legacy binary object files and executable files


### PR DESCRIPTION
On a non-Intel-compiler system, must override both CC and CXX to build benchmarks.